### PR TITLE
Add ProVerif model and PVL for RFC8446

### DIFF
--- a/pv/tls-lib-rfc8446.pvl
+++ b/pv/tls-lib-rfc8446.pvl
@@ -1,0 +1,745 @@
+(********************************************************)
+(*  Security and Threat Model *)
+(********************************************************)
+
+free io:channel.
+const zero: bitstring.
+const empty_string: bitstring. (* "" in the RFC *)
+
+(********************************************************)
+(* Authenticated Encryption with Additional Data *)
+(* extended with with weak/strong algorithms: See Lucky13, Beast, RC4 *)
+(********************************************************)
+
+type ae_alg.
+const WeakAE, StrongAE: ae_alg.
+type ae_key.
+fun b2ae(bitstring):ae_key [data].
+
+fun aead_enc(ae_alg, ae_key, bitstring, bitstring, bitstring): bitstring.
+fun aead_forged(bitstring,bitstring): bitstring.
+
+fun aead_dec(ae_alg, ae_key, bitstring, bitstring, bitstring): bitstring
+reduc forall a:ae_alg, k:ae_key, n:bitstring, p:bitstring, ad:bitstring;
+    aead_dec(a, k, n, ad, aead_enc(a, k, n, ad, p)) = p
+otherwise forall a:ae_alg, k:ae_key, n:bitstring, p:bitstring, ad:bitstring,p':bitstring,ad':bitstring;
+    aead_dec(WeakAE, k, n, ad, aead_forged(p,aead_enc(WeakAE, k, n, ad', p'))) = p.
+
+fun aead_leak(bitstring):bitstring
+reduc forall k:ae_key, n:bitstring, ad:bitstring, x:bitstring;
+      aead_leak(aead_enc(WeakAE,k,n,ad,x)) = x.
+
+(********************************************************)
+(* Diffie-Hellman with small/bad subgroup attacks. See Logjam, Cross-Protocol *)
+(********************************************************)
+
+type group.
+const StrongDH: group [data].
+const WeakDH: group [data].
+
+type element.
+fun e2b(element): bitstring [data,typeConverter].
+const BadElement: element [data].
+const G: element [data].
+
+fun dh_ideal(element,bitstring):element.
+equation forall x:bitstring, y:bitstring;
+	 dh_ideal(dh_ideal(G,x),y) =
+	 dh_ideal(dh_ideal(G,y),x).
+
+fun dh_exp(group,element,bitstring):element
+reduc forall g:group, e:element, x:bitstring;
+      dh_exp(WeakDH,e,x) = BadElement
+otherwise forall g:group, e:element, x:bitstring;
+      dh_exp(StrongDH,BadElement,x) = BadElement
+otherwise forall g:group, e:element, x:bitstring;
+      dh_exp(StrongDH,e,x) = dh_ideal(e,x).
+
+letfun dh_keygen(g:group) =
+       new x:bitstring;
+       let gx = dh_exp(g,G,x) in
+       (x,gx).
+
+(********************************************************)
+(* Hash Functions, including those with collisions. See SLOTH *)
+(********************************************************)
+
+type hash_alg.
+const StrongHash: hash_alg [data].
+const WeakHash: hash_alg [data].
+
+const collision:bitstring [data].
+fun hash_ideal(bitstring):bitstring.
+
+fun hash(hash_alg,bitstring): bitstring
+reduc forall x:bitstring;
+      hash(WeakHash,x) = collision
+otherwise forall x:bitstring;
+      hash(StrongHash,x) = hash_ideal(x).
+
+(********************************************************)
+(* HMAC *)
+(********************************************************)
+
+type mac_key.
+fun b2mk(bitstring):mac_key [data,typeConverter].
+
+fun hmac_ideal(mac_key,bitstring): bitstring.
+
+fun hmac(hash_alg,mac_key,bitstring):bitstring
+reduc forall k:mac_key, x:bitstring;
+      hmac(WeakHash,k, x) = collision
+otherwise forall x:bitstring, k:mac_key;
+      hmac(StrongHash,k, x) = hmac_ideal(k,x).
+
+(********************************************************)
+(* Public Key Signatures *)
+(********************************************************)
+
+type privkey.
+type pubkey.
+fun pk(privkey): pubkey.
+const NoPubKey:pubkey.
+
+(* RSA Signatures, typically the argument is a hash over some data *)
+
+fun sign(privkey,bitstring):bitstring.
+
+fun verify(pubkey,bitstring,bitstring): bool
+reduc forall k:privkey, x:bitstring;
+      verify(pk(k),x,sign(k,x)) = true.
+
+
+(********************************************************)
+(* Public Key Encryption with decryption and signing oracle *)
+(* for weak decrytion algorithsm (PKCS1). See DROWN/Bleichenbacher *)
+(********************************************************)
+
+type rsa_alg.
+const WeakRSAKey: privkey.
+const WeakRSADecryption, StrongRSADecryption:rsa_alg.
+
+fun rsa_enc(pubkey,bitstring): bitstring.
+
+type result.
+fun success(bitstring,bitstring):result [data].
+fun failure(bitstring):result [data].
+
+fun rsa_dec(rsa_alg,privkey,bitstring): result
+reduc forall k:privkey, x:bitstring;
+      rsa_dec(StrongRSADecryption,k,rsa_enc(pk(k),x)) = success(x,zero)
+otherwise forall k:privkey, x:bitstring;
+      rsa_dec(WeakRSADecryption,k,rsa_enc(pk(k),x)) = success(x,(x,sign(k,x))).
+
+
+(********************************************************)
+(* Long term keys *)
+(********************************************************)
+
+type prin.
+table longTermKeys(prin,privkey,pubkey).
+
+type preSharedKey.
+const NoPSK: preSharedKey.
+fun PSK(bitstring): preSharedKey [data].
+fun psk2b(preSharedKey): bitstring
+reduc forall b:bitstring; psk2b(PSK(b)) = b
+otherwise psk2b(NoPSK) = zero.
+
+table preSharedKeys(prin,prin,preSharedKey).
+
+event Reachable(bitstring).
+event WeakOrCompromisedKey(pubkey).
+event CompromisedPreSharedKey(preSharedKey).
+event PostSessionCompromisedKey(pubkey).
+
+let longTermKeysProc() =
+    event WeakOrCompromisedKey(NoPubKey)
+ |  (in(io,a:prin);
+     new k:privkey;
+     insert longTermKeys(a,k,pk(k));
+     out(io,pk(k)))
+ |  (in(io,(a:prin,k:privkey));
+     event WeakOrCompromisedKey(pk(k));
+     insert longTermKeys(a,k,pk(k)))
+ |  (in(io,(a:prin,b:prin));
+     new pskAB:bitstring;
+     insert preSharedKeys(a,b,PSK(pskAB)))
+ |  (in(io,(a:prin,b:prin));
+     new pskAB:bitstring;
+     event CompromisedPreSharedKey(PSK(pskAB));
+     insert preSharedKeys(a,b,PSK(pskAB));
+     out(io,pskAB)).
+
+const A,B,M: prin.
+let fixedLongTermKeys() =
+     new skA: privkey;
+     new skB: privkey;
+     new skM: privkey;
+     let pkA = pk(skA) in
+     let pkB = pk(skB) in
+     let pkM = pk(skM) in
+     new pskAB: bitstring;
+     new pskAM: bitstring;
+     new pskMB: bitstring;
+     insert longTermKeys(A,skA,pkA);
+     insert longTermKeys(B,skB,pkB);
+     insert longTermKeys(M,skM,pkM);
+     insert preSharedKeys(A,B,PSK(pskAB));
+     insert preSharedKeys(A,M,PSK(pskAM));
+     insert preSharedKeys(M,B,PSK(pskMB));
+     event WeakOrCompromisedKey(NoPubKey);
+     event WeakOrCompromisedKey(pkM);
+     event CompromisedPreSharedKey(PSK(pskAM));
+     event CompromisedPreSharedKey(PSK(pskMB));
+     out(io,(skM,pskAM,pskMB)).
+
+
+(********************************************************)
+(*  TLS 1.3 Key Schedule  *)
+(********************************************************)
+
+type label.
+const client_finished, server_finished, master_secret,
+      client_key_expansion, server_key_expansion: label.
+const tls13_client_handshake_traffic_secret,
+      tls13_server_handshake_traffic_secret,
+      tls13_client_early_traffic_secret,
+      tls13_client_application_traffic_secret,
+      tls13_server_application_traffic_secret,
+      tls13_key, tls13_iv,
+      tls13_early_exporter_master_secret,
+      tls13_exporter_master_secret,
+      tls13_resumption_master_secret,
+      tls13_resumption_psk_binder_key,
+      tls13_resumption,
+      tls13_finished,tls13_derived: label.
+
+fun tls12_prf(bitstring,label,bitstring): bitstring.
+
+letfun prf(k:bitstring,x:bitstring) =
+       hmac(StrongHash,b2mk(k),x).
+
+letfun hkdf_extract(s:bitstring,k:bitstring) =
+       prf(s,k).
+
+letfun hkdf_expand_label(k:bitstring,l:label,h:bitstring) =
+       prf(k,(l,h)).
+
+letfun derive_secret(k:bitstring,l:label,m:bitstring) =
+       hkdf_expand_label(k,l,hash(StrongHash,m)).
+
+letfun kdf_0() = hkdf_extract(zero,zero).
+
+letfun kdf_es(psk:preSharedKey) =
+       let es = hkdf_extract(zero,psk2b(psk)) in
+       let kb = derive_secret(es,tls13_resumption_psk_binder_key,empty_string) in
+       (es,b2mk(kb)).
+
+
+letfun kdf_k0(es:bitstring,log:bitstring) =
+       let atsc0 = derive_secret(es, tls13_client_early_traffic_secret, log) in
+       let kc0   = hkdf_expand_label(atsc0,tls13_key,empty_string) in
+       let ems0   = derive_secret(es,tls13_early_exporter_master_secret,log) in
+       (b2ae(kc0),ems0).
+
+
+letfun kdf_hs(es:bitstring,e:bitstring) =
+       let extra = derive_secret(es,tls13_derived,empty_string) in
+       hkdf_extract(extra,e).
+
+letfun kdf_ms(hs:bitstring,log:bitstring) =
+       let extra = derive_secret(hs,tls13_derived,empty_string) in
+       let ms =   hkdf_extract(extra, zero) in
+       let htsc = derive_secret(hs, tls13_client_handshake_traffic_secret, log) in
+       let htss = derive_secret(hs, tls13_server_handshake_traffic_secret, log) in
+       let kch =  hkdf_expand_label(htsc,tls13_key,empty_string) in
+       let kcm =  hkdf_expand_label(htsc,tls13_finished,empty_string) in
+       let ksh =  hkdf_expand_label(htss,tls13_key,empty_string) in
+       let ksm =  hkdf_expand_label(htss,tls13_finished,empty_string) in
+       (ms,b2ae(kch),b2ae(ksh),b2mk(kcm),b2mk(ksm)).
+
+letfun kdf_k(ms:bitstring,log:bitstring) =
+       let atsc = derive_secret(ms, tls13_client_application_traffic_secret, log) in
+       let atss = derive_secret(ms, tls13_server_application_traffic_secret, log) in
+       let ems 	= derive_secret(ms, tls13_exporter_master_secret, log) in
+       let kc   = hkdf_expand_label(atsc,tls13_key,empty_string) in
+       let ks   = hkdf_expand_label(atss,tls13_key,empty_string) in
+       (b2ae(kc),b2ae(ks),ems).
+
+letfun kdf_psk(ms:bitstring, log:bitstring) =
+       derive_secret(ms,tls13_resumption_master_secret,log).
+
+letfun kdf_res_psk(rms:bitstring, ticket_nonce:bitstring) =
+       hkdf_expand_label(rms,tls13_resumption,ticket_nonce).
+
+
+(********************************************************)
+(*  Message Formats, Session State *)
+(********************************************************)
+
+type random.
+type version.
+const TLS12, TLS13: version.
+type kex_alg.
+fun RSA(rsa_alg):kex_alg [data].
+fun DHE(group):kex_alg [data].
+fun DHE_13(group,element): kex_alg [data].
+
+type psk_type.
+fun Binder(bitstring): psk_type [data].
+fun NoBinder(): psk_type [data].
+
+type params.
+fun nego(version,kex_alg,hash_alg,ae_alg,psk_type): params [data].
+
+type msg.
+fun msg2bytes(msg):bitstring [data,typeConverter].
+fun CH(random,params):msg [data].
+fun SH(random,params):msg [data].
+fun CRT(pubkey):msg [data].
+fun SKE(group,element,bitstring):msg [data].
+fun CKE(bitstring): msg [data].
+fun CV(bitstring):msg [data].
+fun FIN(bitstring):msg [data].
+
+event ClientOffersVersion(random,version).
+event ClientOffersKEX(random,kex_alg).
+event ClientOffersAE(random,ae_alg).
+event ClientOffersHash(random,hash_alg).
+
+event ClientFinished(version,random,random,
+                     preSharedKey,pubkey,
+		     params,params,
+		     ae_key,ae_key,bitstring,bitstring).
+
+event ClientFinished0(version,random,preSharedKey,
+  		      params,ae_key,bitstring).
+
+event ServerChoosesVersion(random,random,pubkey,version).
+event ServerChoosesKEX(random,random,pubkey,version,kex_alg).
+event ServerChoosesAE(random,random,pubkey,version,ae_alg).
+event ServerChoosesHash(random,random,pubkey,version,hash_alg).
+
+event ServerFinished0(version,random,preSharedKey,
+		     params,ae_key).
+
+event ServerFinished(version,random,random,
+                     preSharedKey,pubkey,
+		     params,params,
+		     ae_key,ae_key,bitstring,bitstring).
+event PreServerFinished(version,random,random,
+			preSharedKey,pubkey,
+			params,params,
+			ae_key,ae_key,bitstring).
+
+table clientSession(random,random,preSharedKey,pubkey,
+		    params,params,
+		    ae_key,ae_key,bitstring,bitstring).
+table serverSession(random,random,preSharedKey,pubkey,
+		    params,params,
+		    ae_key,ae_key,bitstring,bitstring).
+
+table serverSession0_5(random,random,preSharedKey,pubkey,
+		    params,params,
+		    ae_key,ae_key,bitstring).
+
+table clientSession0(random,preSharedKey,params,ae_key,bitstring).
+table serverSession0(random,preSharedKey,params,ae_key,bitstring).
+
+table clientResumptionTicket(random,random,pubkey,preSharedKey).
+table serverResumptionTicket(random,random,pubkey,preSharedKey).
+
+(********************************************************)
+(*  Security Events  *)
+(********************************************************)
+
+event ClientAEKeyLeaked(version,random,random,preSharedKey,pubkey).
+event ServerAEKeyLeaked(version,random,random,preSharedKey,pubkey).
+event ClientAEKeyLeaked0(version,random,preSharedKey,params).
+event ServerAEKeyLeaked0(version,random,preSharedKey,params).
+
+let secrecyQuery() =
+    (get clientSession(cr,sr,psk,p,o,m,ck,sk,cb,ms) in
+     let nego(v,kkk,hhh,aaa,ppp) = m in
+     in (io,=ck);
+     event ClientAEKeyLeaked(v,cr,sr,psk,p))
+ |  (get serverSession(cr,sr,psk,p,o,m,ck,sk,cb,ms) in
+     let nego(v,kkk,hhh,aaa,ppp) = m in
+     in (io,=sk);
+     event ServerAEKeyLeaked(v,cr,sr,psk,p))
+ |  (get clientSession0(cr,psk,o,ck,ems) in
+     in (io,=ck);
+     event ClientAEKeyLeaked0(TLS13,cr,psk,o))
+ |  (get serverSession0(cr,psk,o,ck,ems) in
+     in (io,=ck);
+     event ServerAEKeyLeaked0(TLS13,cr,psk,o)).
+
+event MatchingChannelBinding(version,random,random,pubkey,version,random,random,pubkey).
+event MatchingResumptionSecret(version,random,random,pubkey,version,random,random,pubkey).
+event MatchingAEKey(version,random,random,pubkey,version,random,random,pubkey).
+event MatchingAEKey0(version,random,preSharedKey,params,random,preSharedKey,params).
+event MatchingEMS0(version,random,preSharedKey,params,random,preSharedKey,params).
+event MatchingResumptionPSK(version,random,random,pubkey,version,random,random,pubkey).
+event ResumptionPSKDerived(version,random,random,pubkey,preSharedKey).
+
+let channelBindingQuery() =
+    (get clientSession0(cr,psk,o,ck,ems) in
+     get serverSession0(cr',psk',o',=ck,ems) in
+     if (cr <> cr' || psk <> psk' || o <> o') then
+	 event MatchingAEKey0(TLS13,cr,psk,o,cr',psk',o'))
+|   (get clientSession0(cr,psk,o,ck,ems) in
+     get serverSession0(cr',psk',o',ck,=ems) in
+     if (cr <> cr' || psk <> psk' || o <> o') then
+	 event MatchingEMS0(TLS13,cr,psk,o,cr',psk',o'))
+|   (get clientSession(cr,sr,psk,p,o,m,ck,sk,cb,ms) in
+     get serverSession(cr',sr',psk',p',o',m',ck',sk',=cb,ms') in
+     let nego(v,kkk,hhh,aaa,ppp) = m in
+     let nego(v',kkk',hhh',aaa',ppp') = m' in
+     if (cr <> cr' || sr <> sr' || p <> p') then
+	 event MatchingChannelBinding(v,cr,sr,p,v',cr',sr',p'))
+|   (get clientSession(cr,sr,psk,p,o,m,ck,sk,cb,ms) in
+     get serverSession(cr',sr',psk',p',o',m',ck',sk',cb',=ms) in
+     let nego(v,kkk,hhh,aaa,ppp) = m in
+     let nego(v',kkk',hhh',aaa',ppp') = m' in
+     if (cr <> cr' || sr <> sr' || p <> p') then
+	 event MatchingResumptionSecret(v,cr,sr,p,v',cr',sr',p'))
+|   (get clientSession(cr,sr,psk,p,o,m,ck,sk,cb,ms) in
+     get serverSession(cr',sr',psk',p',o',m',=ck,=sk,cb',ms') in
+     let nego(v,kkk,hhh,aaa,ppp) = m in
+     let nego(v',kkk',hhh',aaa',ppp') = m' in
+     if (cr <> cr' || sr <> sr' || p <> p') then
+	 event MatchingAEKey(v,cr,sr,p,v',cr',sr',p'))
+|   (get clientResumptionTicket(cr,sr,p,rpsk) in
+     get serverResumptionTicket(cr',sr',p',=rpsk) in
+     if (cr <> cr' || sr <> sr' || p <> p') then
+	 event MatchingResumptionPSK(TLS13,cr,sr,p,TLS13,cr',sr',p')).
+
+
+(********************************************************)
+(*  Sanity Queries: should all be false  *)
+(********************************************************)
+
+query cr:random, sr:random,
+      psk:preSharedKey,p:pubkey,o:params, m:params,
+      ck:ae_key, sk:ae_key, cb:bitstring, ms:bitstring;
+      event(ClientFinished(TLS12,cr,sr,psk,p,m,o,ck,sk,cb,ms)) ==>
+      event(ServerFinished(TLS12,cr,sr,psk,p,m,o,ck,sk,cb,ms)).
+
+query cr:random, sr:random,
+      psk:preSharedKey,p:pubkey,o:params, m:params,
+      ck:ae_key, sk:ae_key, cb:bitstring, ms:bitstring;
+      event(ClientFinished(TLS13,cr,sr,psk,p,m,o,ck,sk,cb,ms)) ==>
+      event(PreServerFinished(TLS13,cr,sr,psk,p,m,o,ck,sk,cb)).
+
+query cr:random, sr:random,
+      psk:preSharedKey,p:pubkey,o:params, m:params,
+      ck:ae_key, sk:ae_key, cb:bitstring, ms:bitstring;
+      event(ServerFinished(TLS12,cr,sr,psk,p,m,o,ck,sk,cb,ms)).
+
+query cr:random, sr:random,
+      psk:preSharedKey,p:pubkey,o:params, m:params,
+      ck:ae_key, sk:ae_key, cb:bitstring, ms:bitstring;
+      event(ClientFinished(TLS12,cr,sr,psk,p,m,o,ck,sk,cb,ms)).
+
+query cr:random, sr:random,
+      psk:preSharedKey,p:pubkey,o:params, m:params,
+      ck:ae_key, sk:ae_key, cb:bitstring, ms:bitstring;
+      event(ServerFinished(TLS13,cr,sr,psk,p,m,o,ck,sk,cb,ms)).
+
+query cr:random, sr:random,
+      psk:preSharedKey,p:pubkey,o:params, m:params,
+      ck:ae_key, sk:ae_key, cb:bitstring, ms:bitstring;
+      event(PreServerFinished(TLS13,cr,sr,psk,p,m,o,ck,sk,cb)).
+
+query cr:random, sr:random,
+      psk:preSharedKey,p:pubkey,o:params, m:params,
+      ck:ae_key, sk:ae_key, cb:bitstring, ms:bitstring;
+      event(ClientFinished(TLS13,cr,sr,psk,p,m,o,ck,sk,cb,ms)).
+
+
+(********************************************************)
+(*  TLS 1.2 Processes: no client auth, DHE + RSA *)
+(********************************************************)
+
+let Client12() =
+    (new cr:random;
+     in(io,offer:params);
+     out(io,CH(cr,offer));
+     in(io,SH(sr,mode));
+     let nego(=TLS12,k,h,a,pt) = mode in
+     let v = TLS12 in
+     let log = (CH(cr,offer),SH(sr,mode)) in
+     in(io,CRT(p));
+     let log = (log,CRT(p)) in
+     get longTermKeys(sn,xxx,=p) in
+     let DHE(g) = k in
+      (in(io,SKE(=g,e,s));
+       let log = (log,SKE(g,e,s)) in
+       if verify(p,hash(h,(cr,sr,g,e)),s) = true then
+          let (x:bitstring,gx:element) = dh_keygen(g) in
+	  let pms = e2b(dh_exp(g,e,x)) in
+	  let ms = tls12_prf(pms,master_secret,(cr,sr)) in
+	  out(io,CKE(e2b(gx)));
+	  let log = (log,CKE(e2b(gx))) in
+	  let m1 = tls12_prf(ms,client_finished,log) in
+          out(io,FIN(m1));
+	  let log = (log,FIN(m1)) in
+	  in(io,FIN(m2));
+	  if m2 = tls12_prf(ms,server_finished,log) then
+	     let ck = b2ae(tls12_prf(ms,client_key_expansion,(sr,cr))) in
+	     let sk = b2ae(tls12_prf(ms,server_key_expansion,(sr,cr))) in
+	     event ClientFinished(TLS12,cr,sr,NoPSK,p,offer,mode,ck,sk,m1,ms);
+	     insert clientSession(cr,sr,NoPSK,p,offer,mode,ck,sk,m1,ms))
+    else let RSA(r) = k in
+      (new pms: bitstring;
+       let ms = tls12_prf(pms,master_secret,(cr,sr)) in
+       out(io,CKE(rsa_enc(p,pms)));
+       let log = (log,CKE(rsa_enc(p,pms))) in
+       let m1 = tls12_prf(ms,client_finished,log) in
+       out(io,FIN(m1));
+       let log = (log,FIN(m1)) in
+       in(io,FIN(m2));
+       if m2 = tls12_prf(ms,server_finished,log) then
+          let ck = b2ae(tls12_prf(ms,client_key_expansion,(sr,cr))) in
+          let sk = b2ae(tls12_prf(ms,server_key_expansion,(sr,cr))) in
+	  event ClientFinished(TLS12,cr,sr,NoPSK,p,offer,mode,ck,sk,m1,ms);
+	  insert clientSession(cr,sr,NoPSK,p,offer,mode,ck,sk,m1,ms))).
+
+
+let Server12() =
+    (in(io,CH(cr,offer));
+     in(io,SH(xxx,mode));
+     let nego(=TLS12,k,h,a,pt) = mode in
+     let v = TLS12 in
+     new sr:random;
+     out(io,SH(sr,mode));
+     let log = (CH(cr,offer),SH(sr,mode)) in
+     get longTermKeys(sn,sk,p) in
+     event ServerChoosesVersion(cr,sr,p,v);
+     event ServerChoosesKEX(cr,sr,p,v,k);
+     event ServerChoosesAE(cr,sr,p,v,a);
+     event ServerChoosesHash(cr,sr,p,v,h);
+     out(io,CRT(p));
+     let log = (log,CRT(p)) in
+     let DHE(g) = k in
+      (let (y:bitstring, gy:element) = dh_keygen(g) in
+       let sg = sign(sk,hash(h,(cr,sr,g,gy))) in
+       out(io,SKE(g,gy,sg));
+       let log = (log,SKE(g,gy,sg)) in
+       in (io,CKE(e2b(gx)));
+       let log = (log,CKE(e2b(gx))) in
+       let pms = e2b(dh_exp(g,gx,y)) in
+       let ms = tls12_prf(pms,master_secret,(cr,sr)) in
+       in(io,FIN(m1));
+       if m1 = tls12_prf(ms,client_finished,log) then
+	  let log = (log,FIN(m1)) in
+	  let m2 = tls12_prf(ms,server_finished,log) in
+          let cak = b2ae(tls12_prf(ms,client_key_expansion,(sr,cr))) in
+          let sak = b2ae(tls12_prf(ms,server_key_expansion,(sr,cr))) in
+	  event ServerFinished(TLS12,cr,sr,NoPSK,p,offer,mode,cak,sak,m1,ms);
+	  out (io,FIN(m2));
+	  insert serverSession(cr,sr,NoPSK,p,offer,mode,cak,sak,m1,ms);
+ 	  phase 1;
+          event PostSessionCompromisedKey(pk(sk));
+	  out(io,sk))
+    else let RSA(r) = k in
+      (in(io,CKE(epms));
+       let log = (log,CKE(epms)) in
+       let success(pms,leak) = rsa_dec(r,sk,epms) in
+       out (io,leak);
+       let ms = tls12_prf(pms,master_secret,(cr,sr)) in
+       in(io,FIN(m1));
+       if m1 = tls12_prf(ms,client_finished,log) then
+	  let log = (log,FIN(m1)) in
+	  let m2 = tls12_prf(ms,server_finished,log) in
+          let cak = b2ae(tls12_prf(ms,client_key_expansion,(sr,cr))) in
+          let sak = b2ae(tls12_prf(ms,server_key_expansion,(sr,cr))) in
+	  event ServerFinished(TLS12,cr,sr,NoPSK,p,offer,mode,cak,sak,m1,ms);
+	  out (io,FIN(m2));
+	  insert serverSession(cr,sr,NoPSK,p,offer,mode,cak,sak,m1,ms);
+ 	  phase 1;
+          event PostSessionCompromisedKey(pk(sk));
+	  out (io,sk))).
+
+
+(********************************************************)
+(*  TLS 1.3 0+1-RTT Processes: no client auth, uses psk (potentially NoPSK) *)
+(********************************************************)
+
+
+let Client13() =
+    (get preSharedKeys(a,b,psk) in
+     in (io,ioffer:params);
+     let nego(=TLS13,DHE_13(g,eee),hhh,aaa,pt) = ioffer in
+     new cr:random;
+     let (x:bitstring,gx:element) = dh_keygen(g) in
+     let (early_secret:bitstring,kb:mac_key) = kdf_es(psk) in
+     let zoffer = nego(TLS13,DHE_13(g,gx),hhh,aaa,Binder(zero)) in
+     let pt = Binder(hmac(StrongHash,kb,msg2bytes(CH(cr,zoffer)))) in
+     let offer = nego(TLS13,DHE_13(g,gx),hhh,aaa,pt) in
+     let ch = CH(cr,offer) in
+     event ClientOffersVersion(cr,TLS13);
+     event ClientOffersKEX(cr,DHE_13(g,gx));
+     event ClientOffersAE(cr,aaa);
+     event ClientOffersHash(cr,hhh);
+     out(io,ch);
+     let (kc0:ae_key,ems0:bitstring) = kdf_k0(early_secret,msg2bytes(ch)) in
+     insert clientSession0(cr,psk,offer,kc0,ems0);
+
+     in(io,SH(sr,mode));
+     let nego(=TLS13,DHE_13(=g,gy),h,a,spt) = mode in
+     let log = (ch,SH(sr,mode)) in
+
+     let gxy = e2b(dh_exp(g,gy,x)) in
+     let handshake_secret = kdf_hs(early_secret,gxy) in
+     let (master_secret:bitstring,chk:ae_key,shk:ae_key,cfin:mac_key,sfin:mac_key) =
+         kdf_ms(handshake_secret,log) in
+     out(io,(chk,shk));
+
+     in(io,CRT(p));
+     let log = (log,CRT(p)) in
+     get longTermKeys(sn,xxx,=p) in
+     in(io,CV(s));
+     if verify(p,hash(h,log),s) = true then
+     let log = (log,CV(s)) in
+     in(io,FIN(m1));
+     if m1 = hmac(StrongHash,sfin,log) then (
+        let log = (log,FIN(m1)) in
+	let (cak:ae_key,sak:ae_key,ems:bitstring) = kdf_k(master_secret,log) in
+        let m2 = hmac(StrongHash,cfin,log) in
+        let log = (log,FIN(m2)) in
+	let rms =  kdf_psk(master_secret,log) in
+
+        event ClientFinished(TLS13,cr,sr,psk,p,offer,mode,cak,sak,ems,rms);
+        insert clientSession(cr,sr,psk,p,offer,mode,cak,sak,ems,rms);
+        out(io,FIN(m2));
+        in(io,ticket_nonce:bitstring);
+        let resumption_psk = PSK(kdf_res_psk(rms,ticket_nonce)) in
+        event ResumptionPSKDerived(TLS13,cr,sr,p,resumption_psk);
+        insert clientResumptionTicket(cr,sr,p,resumption_psk))).
+
+
+let Server13() =
+    (get preSharedKeys(a,b,psk) in
+     in(io,ch:msg);
+     let CH(cr,offer) = ch in
+     let nego(=TLS13,DHE_13(g,gx),hhh,aaa,Binder(m)) = offer in
+     let (early_secret:bitstring,kb:mac_key) = kdf_es(psk) in
+     let zoffer = nego(TLS13,DHE_13(g,gx),hhh,aaa,Binder(zero)) in
+     if m = hmac(StrongHash,kb,msg2bytes(CH(cr,zoffer))) then
+     let (kc0:ae_key,ems0:bitstring) =
+         kdf_k0(early_secret,msg2bytes(ch)) in
+     insert serverSession0(cr,psk,offer,kc0,ems0);
+
+     new sr:random;
+     in(io,SH(xxx,mode));
+     let nego(=TLS13,DHE_13(=g,eee),h,a,pt) = mode in
+     let (y:bitstring,gy:element) = dh_keygen(g) in
+     let mode = nego(TLS13,DHE_13(g,gy),h,a,pt) in
+     out(io,SH(sr,mode));
+     let log = (ch,SH(sr,mode)) in
+     get longTermKeys(sn,sk,p) in
+     event ServerChoosesVersion(cr,sr,p,TLS13);
+     event ServerChoosesKEX(cr,sr,p,TLS13,DHE_13(g,gy));
+     event ServerChoosesAE(cr,sr,p,TLS13,a);
+     event ServerChoosesHash(cr,sr,p,TLS13,h);
+
+     let gxy = e2b(dh_exp(g,gx,y)) in
+     let handshake_secret = kdf_hs(early_secret,gxy) in
+     let (master_secret:bitstring,chk:ae_key,shk:ae_key,cfin:mac_key,sfin:mac_key) =
+         kdf_ms(handshake_secret,log) in
+     out(io,(chk,shk));
+
+     out(io,CRT(p));
+     let log = (log,CRT(p)) in
+     let sg = sign(sk,hash(h,log)) in
+     out(io,CV(sg));
+     let log = (log,CV(sg)) in
+     let m1 = hmac(StrongHash,sfin,log) in
+
+     let log = (log,FIN(m1)) in
+
+     let (cak:ae_key,sak:ae_key,ems:bitstring) = kdf_k(master_secret,log) in
+     event PreServerFinished(TLS13,cr,sr,psk,p,offer,mode,cak,sak,ems);
+     out(io,FIN(m1));
+
+
+     in(io,FIN(m2));
+     if m2 = hmac(StrongHash,cfin,log) then
+        let log = (log,FIN(m2)) in
+	let rms =  kdf_psk(master_secret,log) in
+        event ServerFinished(TLS13,cr,sr,psk,p,offer,mode,cak,sak,ems,rms);
+        insert serverSession(cr,sr,psk,p,offer,mode,cak,sak,ems,rms);
+        new ticket_nonce:bitstring;
+        out(io,ticket_nonce);
+        let resumption_psk = PSK(kdf_res_psk(rms,ticket_nonce)) in
+        event ResumptionPSKDerived(TLS13,cr,sr,p,resumption_psk);
+        insert serverResumptionTicket(cr,sr,p,resumption_psk);
+        phase 1;
+        event PostSessionCompromisedKey(pk(sk));
+	out(io,sk)).
+(********************************************************)
+(*  Application Data Client and Server (+Record Layer) *)
+(********************************************************)
+
+
+event ClientSends0(version,random,preSharedKey,bitstring,bitstring,bitstring).
+event ServerReceives0(version,random,preSharedKey,bitstring,bitstring,bitstring).
+event ClientSends(version,random,random,preSharedKey,pubkey,bitstring,bitstring,bitstring).
+event ServerSends(version,random,random,preSharedKey,pubkey,bitstring,bitstring,bitstring).
+event ClientReceives(version,random,random,preSharedKey,pubkey,bitstring,bitstring,bitstring).
+event ServerReceives(version,random,random,preSharedKey,pubkey,bitstring,bitstring,bitstring).
+
+
+fun m_c0(version,random,preSharedKey): bitstring [private].
+fun m_s(version,random,random,pubkey,preSharedKey): bitstring [private].
+fun m_c(version,random,random,pubkey,preSharedKey): bitstring [private].
+
+let appData() =
+    (get clientSession0(cr,psk,o,kc0,ems0) in
+     let nego(v,kkk,hhh,a,pt) = o in
+     in (io,(n:bitstring, ad:bitstring));
+     let mesg = m_c0(TLS13,cr,psk) in
+     event ClientSends0(TLS13,cr,psk,n,ad,mesg);
+     out (io,aead_enc(a,kc0,n,ad,mesg)))
+  |
+    (get serverSession0(cr,psk,o,kc0,ems0) in
+     let nego(v,kkk,hhh,a,pt) = o in
+     in (io,(n:bitstring, ad:bitstring, c:bitstring));
+     let f = aead_dec(a,kc0,n,ad,c) in
+     event ServerReceives0(TLS13,cr,psk,n,ad,f))
+  |
+    (get serverSession0_5(cr,sr,psk,ps,o,m,kc,ks,ems) in
+     let nego(v,kkk,hhh,a,pt) = m in
+     in (io,(n:bitstring, ad:bitstring));
+     let mesg = m_s(v,cr,sr,ps,psk) in
+     event ServerSends(v,cr,sr,psk,ps,n,ad,mesg);
+     out (io,aead_enc(a,ks,n,ad,mesg)))
+  |
+    (get clientSession(cr,sr,psk,ps,o,m,kc,ks,ems,rms) in
+     let nego(v,kkk,hhh,a,pt) = m in
+     in (io,(n:bitstring, ad:bitstring));
+     let mesg = m_c(v,cr,sr,ps,psk) in
+     event ClientSends(v,cr,sr,psk,ps,n,ad,mesg);
+     out (io,aead_enc(a,kc,n,ad,mesg)))
+  |
+    (get serverSession(cr,sr,psk,ps,o,m,kc,ks,ems,rms) in
+     let nego(v,kkk,hhh,a,pt) = m in
+     in (io,(n:bitstring, ad:bitstring, c:bitstring));
+     let f = aead_dec(a,kc,n,ad,c) in
+     event ServerReceives(v,cr,sr,psk,ps,n,ad,f))
+  |
+    (get serverSession(cr,sr,psk,ps,o,m,kc,ks,ems,rms) in
+     let nego(v,kkk,hhh,a,pt) = m in
+     in (io,(n:bitstring, ad:bitstring));
+     let mesg = m_s(v,cr,sr,ps,psk) in
+     event ServerSends(v,cr,sr,psk,ps,n,ad,mesg);
+     out (io,aead_enc(a,ks,n,ad,mesg)))
+  |
+    (get clientSession(cr,sr,psk,ps,o,m,kc,ks,ems,rms) in
+     let nego(v,kkk,hhh,a,pt) = m in
+     in (io,(n:bitstring, ad:bitstring, c:bitstring));
+     let f = aead_dec(a,ks,n,ad,c) in
+     event ClientReceives(v,cr,sr,psk,ps,n,ad,f))
+.

--- a/pv/tls13-rfc8446-only.pv
+++ b/pv/tls13-rfc8446-only.pv
@@ -1,0 +1,139 @@
+(* Following secrecy queries should fail *)
+query cr:random, sr:random, psk:preSharedKey, p:pubkey, ms:bitstring, aek:ae_key, cb:bitstring, cr':random, sr':random, v:version, e:element;
+      event(ClientAEKeyLeaked(TLS13,cr,sr,psk,p)) ==>
+      (event(WeakOrCompromisedKey(p)) && (psk = NoPSK || event(CompromisedPreSharedKey(psk)))) ||  
+      event(ServerChoosesKEX(cr,sr,p,TLS13,DHE_13(WeakDH,e))).
+
+query cr:random, sr:random, psk:preSharedKey, p:pubkey, ms:bitstring, aek:ae_key, cb:bitstring, cr':random, sr':random, v:version, e:element;
+      event(ClientAEKeyLeaked(TLS13,cr,sr,psk,p)) ==>
+      (event(WeakOrCompromisedKey(p)) && (psk = NoPSK || event(CompromisedPreSharedKey(psk)))) ||  
+      event(ServerChoosesHash(cr',sr',p,TLS13,WeakHash)). 
+
+query cr:random, sr:random, psk:preSharedKey, p:pubkey, ms:bitstring, aek:ae_key, cb:bitstring, cr':random, sr':random, v:version, e:element;
+      event(ClientAEKeyLeaked(TLS13,cr,sr,psk,p)) ==>
+      event(ServerChoosesKEX(cr,sr,p,TLS13,DHE_13(WeakDH,e))) ||     
+      event(ServerChoosesHash(cr',sr',p,TLS13,WeakHash)). 
+
+(* Following authentication queries should fail *)
+query cr:random, sr:random, cr':random, sr':random,
+      psk:preSharedKey,p:pubkey, e:element,
+      o:params, m:params,  
+      ck:ae_key,sk:ae_key,ms:bitstring,cb:bitstring;
+      inj-event(ClientFinished(TLS13,cr,sr,psk,p,o,m,ck,sk,cb,ms)) ==>
+      inj-event(PreServerFinished(TLS13,cr,sr,psk,p,o,m,ck,sk,cb)) ||
+      (event(WeakOrCompromisedKey(p)) &&  (psk = NoPSK || event(CompromisedPreSharedKey(psk)))).
+
+query cr:random, sr:random, cr':random, sr':random,
+      psk:preSharedKey,p:pubkey, e:element,
+      o:params, m:params,  
+      ck:ae_key,sk:ae_key,ms:bitstring,cb:bitstring;
+      inj-event(ClientFinished(TLS13,cr,sr,psk,p,o,m,ck,sk,cb,ms)) ==>
+      inj-event(PreServerFinished(TLS13,cr,sr,psk,p,o,m,ck,sk,cb)) ||
+      (event(WeakOrCompromisedKey(p)) &&  (psk = NoPSK || event(CompromisedPreSharedKey(psk)))) ||  
+      event(ServerChoosesKEX(cr,sr,p,TLS13,DHE_13(WeakDH,e))).
+
+query cr:random, sr:random, cr':random, sr':random,
+      psk:preSharedKey,p:pubkey, e:element,
+      o:params, m:params,  
+      ck:ae_key,sk:ae_key,ms:bitstring,cb:bitstring;
+      inj-event(ClientFinished(TLS13,cr,sr,psk,p,o,m,ck,sk,cb,ms)) ==>
+      inj-event(PreServerFinished(TLS13,cr,sr,psk,p,o,m,ck,sk,cb)) ||
+      event(ServerChoosesKEX(cr,sr,p,TLS13,DHE_13(WeakDH,e))) ||    
+      event(ServerChoosesHash(cr',sr',p,TLS13,WeakHash)). 
+
+query cr:random, sr:random, cr':random, sr':random,
+      psk:preSharedKey,p:pubkey, e:element,
+      o:params, m:params,  
+      ck:ae_key,sk:ae_key,ms:bitstring,cb:bitstring;
+      inj-event(ClientFinished(TLS13,cr,sr,psk,p,o,m,ck,sk,cb,ms)) ==>
+      inj-event(PreServerFinished(TLS13,cr,sr,psk,p,o,m,ck,sk,cb)).
+
+
+(* Main channel-binding query: fails if cb = ms, succeeds if cb = m1 *)
+query cr:random, sr:random, p:pubkey, cr':random, sr':random, p':pubkey;
+      event(MatchingChannelBinding(TLS13,cr,sr,p,TLS13,cr',sr',p')).
+
+(* Following queries fail for TLS 1.2 but should succeed for TLS 1.3 *)
+query cr:random, sr:random, p:pubkey, cr':random, sr':random, p':pubkey;
+      event(MatchingResumptionSecret(TLS13,cr,sr,p,TLS13,cr',sr',p')).
+
+(* RFC 8446 per-ticket resumption PSK: also a unique channel identifier for TLS 1.3 *)
+query cr:random, sr:random, p:pubkey, cr':random, sr':random, p':pubkey;
+      event(MatchingResumptionPSK(TLS13,cr,sr,p,TLS13,cr',sr',p')).
+
+query v:version, cr:random, sr:random, p:pubkey, rpsk:preSharedKey;
+      event(ResumptionPSKDerived(v,cr,sr,p,rpsk)).
+
+query cr:random, sr:random, p:pubkey, cr':random, sr':random, p':pubkey;
+      event(MatchingAEKey(TLS13,cr,sr,p,TLS13,cr',sr',p')).
+
+(* 1-RTT handshake secrecy query: every disjunct is required *)
+
+query cr:random, sr:random, psk:preSharedKey, p:pubkey, ms:bitstring, aek:ae_key, cb:bitstring, cr':random, sr':random, v:version, e:element;
+      event(ClientAEKeyLeaked(TLS13,cr,sr,psk,p)) ==>
+      (event(WeakOrCompromisedKey(p)) && (psk = NoPSK || event(CompromisedPreSharedKey(psk)))) ||  
+      event(ServerChoosesKEX(cr,sr,p,TLS13,DHE_13(WeakDH,e))) ||     
+      event(ServerChoosesHash(cr',sr',p,TLS13,WeakHash)). 
+
+
+(* 1-RTT handshake authentication query: every disjunct is required; commenting any of them results in "false" *)
+
+query cr:random, sr:random, cr':random, sr':random,
+      psk:preSharedKey,p:pubkey, e:element,
+      o:params, m:params,  
+      ck:ae_key,sk:ae_key,ms:bitstring,cb:bitstring;
+      inj-event(ClientFinished(TLS13,cr,sr,psk,p,o,m,ck,sk,cb,ms)) ==>
+      inj-event(PreServerFinished(TLS13,cr,sr,psk,p,o,m,ck,sk,cb)) ||
+      (event(WeakOrCompromisedKey(p)) &&  (psk = NoPSK || event(CompromisedPreSharedKey(psk)))) ||  
+      event(ServerChoosesKEX(cr,sr,p,TLS13,DHE_13(WeakDH,e))) ||    
+      event(ServerChoosesHash(cr',sr',p,TLS13,WeakHash)). 
+
+
+(* Main appData secrecy query: every disjunct is required *)
+query cr:random, sr:random, psk:preSharedKey, p:pubkey, e:element,  ms:bitstring, aek:ae_key, cb:bitstring, cr':random, sr':random, v:version;
+      attacker(m_c(TLS13,cr,sr,p,psk)) ==>
+      (event(WeakOrCompromisedKey(p)) && (psk = NoPSK || event(CompromisedPreSharedKey(psk)))) ||  
+      event(ServerChoosesAE(cr,sr,p,TLS13,WeakAE)) ||     
+      event(ServerChoosesKEX(cr,sr,p,TLS13,DHE_13(WeakDH,e))) ||     
+      event(ServerChoosesHash(cr',sr',p,TLS13,WeakHash)). 
+
+query cr:random, psk:preSharedKey,kex:kex_alg,h:hash_alg,kc0:ae_key,ems0:bitstring,pt:psk_type;
+      attacker(m_c0(TLS13,cr,psk)) ==>
+      (psk = NoPSK || event(CompromisedPreSharedKey(psk))) ||
+      event(ClientOffersAE(cr,WeakAE)).
+
+(* Main appData authentication query: every disjunct is required; commenting any of them results in "false" *)
+(* Replay prevention relies on the recipient not accepting 2 messages with the same (n,ad);
+   it is not explicitly proved in ProVerif. *)
+
+query cr:random, sr:random, cr':random, sr':random, psk:preSharedKey, e:element,
+      p:pubkey, n:bitstring, ad:bitstring, m:bitstring;
+      event(ClientReceives(TLS13,cr,sr,psk,p,n,ad,m)) ==>
+      event(ServerSends(TLS13,cr,sr,psk,p,n,ad,m)) ||
+      (event(WeakOrCompromisedKey(p)) && (psk = NoPSK || event(CompromisedPreSharedKey(psk)))) ||  
+      event(ServerChoosesAE(cr,sr,p,TLS13,WeakAE)) ||    
+      event(ServerChoosesKEX(cr,sr,p,TLS13,DHE_13(WeakDH,e))) ||    
+      event(ServerChoosesHash(cr',sr',p,TLS13,WeakHash)). 
+
+
+query cr:random, sr:random, cr':random, sr':random, psk:preSharedKey, e:element,
+      p:pubkey, n:bitstring, ad:bitstring, m:bitstring;
+      event(ServerReceives(TLS13,cr,sr,psk,p,n,ad,m)) ==>
+      event(ClientSends(TLS13,cr,sr,psk,p,n,ad,m)) ||
+      ((psk = NoPSK || event(CompromisedPreSharedKey(psk)))) ||  
+      event(ServerChoosesAE(cr,sr,p,TLS13,WeakAE)) ||    
+      event(ServerChoosesKEX(cr,sr,p,TLS13,DHE_13(WeakDH,e))) ||    
+      event(ServerChoosesHash(cr',sr',p,TLS13,WeakHash)). 
+
+query cr:random, sr:random, cr':random, sr':random, psk:preSharedKey, e:element,
+      p:pubkey, n:bitstring, ad:bitstring, m:bitstring;
+      event(ServerReceives0(TLS13,cr,psk,n,ad,m)) ==>
+      event(ClientSends0(TLS13,cr,psk,n,ad,m)) ||
+      ((psk = NoPSK || event(CompromisedPreSharedKey(psk)))) ||  
+      event(ClientOffersAE(cr,WeakAE)).
+
+process (
+	 !Client13() | !Server13() | 
+	 !longTermKeysProc() | !appData() |
+	 !secrecyQuery() | !channelBindingQuery() )
+


### PR DESCRIPTION
This adds new ProVerif models reflecting the changes between TLS 1.3 draft 20 and the finalized RFC8446.

Diffing the RFCs end-to-end, I was surprised by the apparently low number of relevant changes that actually touch the ProVerif models:

1. Resumption PSK derivation (RFC 8446 section 4.6.1). In draft-20 a session ticket was bound directly to the `resumption_master_secret` (RMS). RFC 8446 instead derives a fresh PSK per ticket: `PSK = HKDF-Expand-Label(RMS, "resumption", ticket_nonce)` using a new per-ticket "ticket_nonce". This appears to be the only new key-derivation step in the entire RFC.

2. AEAD additional_data (RFC 8446 section 5.2). draft-20 used empty additional_data. RFC 8446 uses the record header (`opaque_type || legacy_record_version || length`). No model change was needed here: the record layer already threads an abstract, attacker-chosen "ad" through aead_enc/aead_dec, which soundly generalizes the concrete record heade (so appData is byte-identical to draft-20.)

Library changes:

* New label: tls13_resumption.

* New key-derivation function: kdf_res_psk(rms, ticket_nonce) = hkdf_expand_label(rms, tls13_resumption, ticket_nonce) i.e. HKDF-Expand-Label(RMS, "resumption", ticket_nonce).

* New tables holding the per-ticket PSK derived by each role: clientResumptionTicket(random, random, pubkey, preSharedKey) serverResumptionTicket(random, random, pubkey, preSharedKey)

* New events:
    ResumptionPSKDerived(...)   - recorded when a role derives a ticket PSK
    MatchingResumptionPSK(...)  - two distinct sessions share a ticket PSK

* Server13: after the handshake completes, and before "phase 1", so the derivation happens before any post-handshake key compromise, the server now picks a fresh ticket_nonce, publishes it (modelling the NewSessionTicket), derives the ticket PSK, and records it in serverResumptionTicket.

* Client13: after sending its Finished, the client receives the ticket_nonce, derives the same ticket PSK, and records it in clientResumptionTicket.

* channelBindingQuery: a new branch matches a client and a server ticket on the derived PSK, and fires MatchingResumptionPSK if they disagree on (client random, server random, server public key). This is the RFC 8446 analogue of the existing MatchingResumptionSecret branch, which is over the RMS itself.

Query changes:

* New: MatchingResumptionPSK query: asserts the per-ticket PSK is a unique channel identifier (expected to hold for TLS 1.3, like MatchingResumptionSecret).

* New: ResumptionPSKDerived reachability query: a sanity check that the new derivation path actually runs.